### PR TITLE
Update AppLogger and GCOverseer requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,11 +18,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/thatfactory/applogger",
-            from: "0.1.0"
+            from: "1.0.0"
         ),
         .package(
             url: "https://github.com/thatfactory/gcoverseer",
-            from: "0.1.0"
+            from: "0.1.1"
         )
     ],
     targets: [


### PR DESCRIPTION
## Summary
- update the `AppLogger` dependency from `0.1.0` to `1.0.0`
- update the `GCOverseer` dependency from `0.1.0` to `0.1.1` so the package can resolve once the compatible `GCOverseer` release exists

## Testing
- not run successfully yet: `swift test` currently cannot resolve until `GCOverseer` `0.1.1` is released, because `0.1.0` still depends on `AppLogger` `< 1.0.0`